### PR TITLE
Add forget subscriber method

### DIFF
--- a/fixtures/subscribers/forget.yml
+++ b/fixtures/subscribers/forget.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://connect.mailerlite.com/api/subscribers/98121614828242796/forget
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Authorization:
+      - "<AUTH>"
+      User-Agent:
+      - MailerLite-client-ruby/1.0.3
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - close
+      Host:
+      - connect.mailerlite.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 01 Sep 2023 13:48:18 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Cache-Control:
+      - no-cache, private
+      X-Locale:
+      - en
+      X-Ratelimit-Limit:
+      - '120'
+      X-Ratelimit-Remaining:
+      - '117'
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Via:
+      - Ingress
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 7ffdf84ede2b1096-HKG
+    body:
+      encoding: UTF-8
+      string: '{"data":{"id":"98121614828242796","email":"test@mail.com","status":"active","source":"api","sent":0,"opens_count":0,"clicks_count":0,"open_rate":0,"click_rate":0,"ip_address":null,"subscribed_at":"2023-09-01
+        13:47:44","unsubscribed_at":null,"created_at":"2023-09-01 13:47:43","updated_at":"2023-09-01
+        13:48:17","deleted_at":"2023-09-01 13:48:17","forget_at":"2023-10-01 13:48:17","fields":{"name":null,"last_name":null,"company":null,"country":null,"city":null,"phone":null,"state":null,"z_i_p":null,"github_handle":null},"groups":[],"location":null,"opted_in_at":null,"optin_ip":null},"message":"Subscriber
+        data will be completely deleted and forgotten within 30 days."}'
+  recorded_at: Fri, 01 Sep 2023 13:48:18 GMT
+recorded_with: VCR 6.2.0

--- a/lib/mailerlite/subscribers/subscribers.rb
+++ b/lib/mailerlite/subscribers/subscribers.rb
@@ -112,5 +112,13 @@ module MailerLite
     def delete(subscriber_id)
       client.http.delete("#{API_URL}/subscribers/#{subscriber_id}")
     end
+
+    # Forgets the specified subscriber.
+    #
+    # @param subscriber_id [String] the ID of the subscriber to forget
+    # @return [HTTP::Response] the response from the API
+    def forget(subscriber_id)
+      client.http.post("#{API_URL}/subscribers/#{subscriber_id}/forget")
+    end
   end
 end

--- a/spec/subscribers_rspec.rb
+++ b/spec/subscribers_rspec.rb
@@ -81,4 +81,16 @@ RSpec.describe MailerLite::Subscribers do
       end
     end
   end
+
+  describe '#forget' do
+    # Use VCR to record and replay the HTTP request
+    it 'forgets a subscriber' do
+      VCR.use_cassette('subscribers/forget') do
+        response = subscribers.forget(98_121_614_828_242_796)
+        body = JSON.parse(response.body)
+        expect(response.status).to eq 200
+        expect(body['message']).to eq 'Subscriber data will be completely deleted and forgotten within 30 days.'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hello, it's me again. Also noticed that we don't have the [forget](https://developers.mailerlite.com/docs/subscribers.html#forget-a-subscriber) method. I added that along with a test. Let me know if you need anything else.