### PR TITLE
feat: make dotenv optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0
+        ruby-version: 3.1
 
     - name: Install Bundler
       run: gem install bundler -v 2.5.23

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
         ruby-version: 3.0
 
     - name: Install Bundler
-      run: gem install bundler -v 2.4.22
+      run: gem install bundler -v 2.5.23
 
     - name: Install dependencies
-      run: bundle _2.4.22_ install
+      run: bundle _2.5.23_ install
 
     - name: Run tests
       run: export MAILERLITE_API_TOKEN=dummy_token && bundle exec rspec spec/*rspec.rb

--- a/.github/workflows/publish_gem.yml
+++ b/.github/workflows/publish_gem.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Set up Ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.1
 
       - name: Install Bundler
-        run: gem install bundler -v 2.4.22
+        run: gem install bundler -v 2.5.23
 
       - name: Install dependencies
-        run: bundle _2.4.22_ install
+        run: bundle _2.5.23_ install
 
       - name: Release Gem
         if: contains(github.ref, 'refs/tags/v')

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.1
   SuggestExtensions: false
   NewCops: enable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [2.0.0] - 2024-12-11
 - *BREAKING CHANGE* - Please check the README file, dotenv is now optional
+- *BREAKING CHANGE* - Updated the required Ruby version from 2.5 to 3.1
 
 ## [1.0.6] - 2024-12-06
 - Page parameter to cursor pagination fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [2.0.0] - 2024-12-11
 - *BREAKING CHANGE* - Please check the README file, dotenv is now optional
-- *BREAKING CHANGE* - Updated the required Ruby version from 2.5 to 3.1
+- *BREAKING CHANGE* - Updated the minimal required Ruby version from 2.5 to 3.1
 
 ## [1.0.6] - 2024-12-06
 - Page parameter to cursor pagination fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.0] - 2024-12-11
+- *BREAKING CHANGE* - Please check the README file, dotenv is now optional
+
 ## [1.0.6] - 2024-12-06
 - Page parameter to cursor pagination fix
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,15 @@ You will have to initalize it in your Ruby file with `require "mailerlite-ruby"`
 
 # Usage
 
-This SDK requires that you either have `.env` file with `MAILERLITE_API_TOKEN` env variable or that your variable is enabled system wide (useful for Docker/Kubernetes). The example of how `MAILERLITE_API_TOKEN` should look like is in `.env.example`.
+This SDK requires that you have the `MAILERLITE_API_TOKEN` environment variable set. You can set this variable in a `.env` file or enable it system-wide (useful for Docker/Kubernetes). The example of how `MAILERLITE_API_TOKEN` should look like is in `.env.example`.
+
+If you want to use `dotenv` to manage your environment variables, you can configure the `mailerlite` gem to load `dotenv`:
+
+```ruby
+MailerLite.configure do |config|
+  config.use_dotenv = true
+end
+```
 
 ## Subscribers
 

--- a/lib/mailerlite/client.rb
+++ b/lib/mailerlite/client.rb
@@ -1,20 +1,30 @@
 # frozen_string_literal: true
 
 require 'http'
-require 'dotenv/load'
 
 MAILERLITE_API_URL = 'https://connect.mailerlite.com/api'
-
-Dotenv.require_keys('MAILERLITE_API_TOKEN')
 
 # mailerlite-ruby is a gem that integrates all endpoints from MailerLite API
 module MailerLite
   attr_reader :api_token
 
+  class << self
+    attr_accessor :use_dotenv
+
+    def configure
+      yield self
+    end
+  end
+
   # Inits the client.
   class Client
-    def initialize(api_token = ENV.fetch('MAILERLITE_API_TOKEN', nil))
-      @api_token = api_token
+    def initialize
+      if MailerLite.use_dotenv
+        require 'dotenv'
+        Dotenv.load
+        Dotenv.require_keys('MAILERLITE_API_TOKEN')
+      end
+      @api_token = ENV.fetch('MAILERLITE_API_TOKEN', nil)
     end
 
     def headers

--- a/lib/mailerlite/version.rb
+++ b/lib/mailerlite/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MailerLite
-  VERSION = '1.0.6'
+  VERSION = '2.0.0'
 end

--- a/mailerlite-ruby.gemspec
+++ b/mailerlite-ruby.gemspec
@@ -27,13 +27,13 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.4.1'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rubocop', '~> 1.7'
+  spec.add_development_dependency 'bundler', '~> 2.5'
+  spec.add_development_dependency 'rake', '~> 13.2'
+  spec.add_development_dependency 'rubocop', '~> 1.69'
   spec.add_dependency 'dotenv', '~> 2.7'
-  spec.add_dependency 'http', '~> 5.0'
-  spec.add_dependency 'json', '~> 2.5'
-  spec.add_dependency 'uri', '~> 0.13.0'
+  spec.add_dependency 'http', '~> 5.2'
+  spec.add_dependency 'json', '~> 2.9'
+  spec.add_dependency 'uri', '~> 1.0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'vcr'

--- a/mailerlite-ruby.gemspec
+++ b/mailerlite-ruby.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = "MailerLite's official Ruby SDK. Interacts with all endpoints at MailerLite API."
   spec.homepage      = 'https://www.MailerLite.com'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.5'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rubocop', '~> 1.69'
-  spec.add_dependency 'dotenv', '~> 2.7'
+  spec.add_dependency 'dotenv', '~> 3.1'
   spec.add_dependency 'http', '~> 5.2'
   spec.add_dependency 'json', '~> 2.9'
   spec.add_dependency 'uri', '~> 1.0'


### PR DESCRIPTION
- making dotenv optional
- updated the minimal required Ruby version from 2.5 to 3.1